### PR TITLE
Update README with Node 18 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,10 @@ Small demo that analyzes a selfie with help from OpenAI and Cloudflare Workers.
 2. Run `wrangler publish` with `CF_API_TOKEN` available.
 
 To populate the KV with advice texts, run `node scripts/seed_kv.js` with the environment variables `CF_API_TOKEN`, `CF_ACCOUNT_ID` and `KV_NAMESPACE_ID` set.
+
+The seeding script requires **Node 18+** for the built-in `fetch` API. If you're on Node 16 or earlier, install [`node-fetch`](https://www.npmjs.com/package/node-fetch) and `require` it at the top of `seed_kv.js`.
+Example for Node 16:
+
+```js
+const fetch = require('node-fetch');
+```


### PR DESCRIPTION
## Summary
- clarify that `scripts/seed_kv.js` needs Node 18+ for the built-in fetch API
- show how to include `node-fetch` on older versions

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6869f59d95b48326b68b1cc4fe598a59