### PR TITLE
Add ARIA roles to spinners

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -25,6 +25,19 @@ body {
     padding: 0 1rem;
 }
 
+/* Utility class for screen-reader-only text */
+.visually-hidden {
+    position: absolute !important;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 /* --- INDEX.HTML --- */
 .header { text-align: center; margin-bottom: 2rem; }
 .header h1 { font-size: 3rem; font-weight: 700; }

--- a/loading.html
+++ b/loading.html
@@ -8,7 +8,9 @@
 </head>
 <body>
     <div class="loading-container">
-        <div class="spinner"></div>
+        <div class="spinner" role="status" aria-label="Loading">
+            <span class="visually-hidden">Зареждане...</span>
+        </div>
         <h1>Анализираме данните...</h1>
         <p>Това може да отнеме до минута. Моля, изчакайте.</p>
     </div>

--- a/results.html
+++ b/results.html
@@ -12,7 +12,9 @@
     <div class="container" id="results-container">
         <!-- Цялото съдържание ще бъде генерирано динамично от JS -->
         <div class="loading-container">
-            <div class="spinner"></div>
+            <div class="spinner" role="status" aria-label="Loading">
+                <span class="visually-hidden">Зареждане...</span>
+            </div>
             <h1>Зареждане на резултатите...</h1>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add visually hidden class for screen readers
- mark loading spinners with `role="status"` and `aria-label="Loading"`

## Testing
- `tidy -errors -q loading.html`
- `tidy -errors -q results.html`


------
https://chatgpt.com/codex/tasks/task_e_6869f5977574832692de53fc818d279a