### PR TITLE
Clarify Node 18 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Small demo that analyzes a selfie with help from OpenAI and Cloudflare Workers.
 
 ## Prerequisites
 
-- **Node.js** v18 or later – required only for the helper scripts.
+- **Node.js** v18 or later – required only for the helper scripts since they rely on the built‑in `fetch` API. On older Node versions install `node-fetch` and import it in `scripts/seed_kv.js`.
 - **Cloudflare account** with a Workers and KV namespace created.
 
 ## Structure

--- a/scripts/seed_kv.js
+++ b/scripts/seed_kv.js
@@ -1,6 +1,18 @@
 // Utility script to populate the KV namespace with default advice texts.
 // Requires the environment variables CF_API_TOKEN, CF_ACCOUNT_ID and KV_NAMESPACE_ID.
 
+// Node 18+ provides a global fetch API. For older versions, fall back to the
+// `node-fetch` package when available.
+if (typeof fetch !== 'function') {
+  try {
+    global.fetch = (...args) =>
+      import('node-fetch').then(({ default: fetch }) => fetch(...args));
+  } catch (err) {
+    console.error('Fetch API not available. Please use Node 18+ or install node-fetch.');
+    process.exit(1);
+  }
+}
+
 const { CF_API_TOKEN, CF_ACCOUNT_ID, KV_NAMESPACE_ID } = process.env;
 
 if (!CF_API_TOKEN || !CF_ACCOUNT_ID || !KV_NAMESPACE_ID) {


### PR DESCRIPTION
## Summary
- handle older Node versions in `scripts/seed_kv.js` by loading `node-fetch` when `fetch` is missing
- note the Node 18+ requirement in the README

## Testing
- `node scripts/seed_kv.js` *(fails: Missing CF_API_TOKEN, CF_ACCOUNT_ID or KV_NAMESPACE_ID)*

------
https://chatgpt.com/codex/tasks/task_e_686a62e85c848326a6cadb350675f9af