### PR TITLE
Add responsive Tailwind tweaks

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -75,6 +75,8 @@ body {
     cursor: pointer;
     display: block;
     font-weight: 600;
+    min-height: 48px;
+    word-break: break-word;
 }
 .cta-button {
     width: 100%;
@@ -87,6 +89,8 @@ body {
     border-radius: 8px;
     cursor: pointer;
     margin-top: 1rem;
+    min-height: 48px;
+    word-break: break-word;
 }
 .cta-button:disabled { background: #95a5a6; cursor: not-allowed; }
 
@@ -165,6 +169,8 @@ body {
     cursor: pointer;
     border-radius: 12px;
     transition: all 0.3s ease;
+    min-height: 48px;
+    word-break: break-word;
 }
 .tab-button.active {
     background-color: var(--primary-color);

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>AI Лицев Анализ</title>
     <link rel="stylesheet" href="css/style.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet" crossorigin="anonymous">
+    <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body>
     <button id="theme-toggle"></button>
@@ -14,7 +15,7 @@
         <p>Получете персонален AI анализ на базата на снимка и начина Ви на живот.</p>
     </header>
 
-    <div class="container">
+    <div class="container sm:flex sm:flex-col sm:w-full">
         <div class="main-content">
             <div class="panel">
                 <h2>1. Попълнете въпросника</h2>

--- a/loading.html
+++ b/loading.html
@@ -5,6 +5,7 @@
     <title>Анализът се извършва...</title>
     <link rel="stylesheet" href="css/style.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="loading-body">
     <div class="loading-container">

--- a/results.html
+++ b/results.html
@@ -6,16 +6,17 @@
     <title>Вашият AI Лицев Анализ</title>
     <link rel="stylesheet" href="css/style.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
     <button id="theme-toggle"></button>
-    <div class="container" id="results-page">
+    <div class="container sm:flex sm:flex-col sm:w-full sm:pb-20" id="results-page">
         <!-- Заглавна карта - винаги видима -->
         <div id="summary-card-container"></div>
         
         <!-- Табове за навигация -->
-        <div class="tabs" id="tabs-container">
+        <div class="tabs sm:fixed sm:bottom-0 sm:left-0 sm:w-full sm:z-10" id="tabs-container">
             <button class="tab-button active" data-tab="overview">Преглед</button>
             <button class="tab-button" data-tab="advice">Препоръки</button>
             <button class="tab-button" data-tab="details">Детайли</button>


### PR DESCRIPTION
## Summary
- import Tailwind on all HTML pages
- make `.container` sections responsive on small screens
- move tab navigation to bottom on mobile
- ensure buttons have minimum height

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_686a880dd99c83269771684e5021c050