### PR TITLE
Add face detection sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,9 +6,16 @@
     <title>AI Лицев Анализ</title>
     <link rel="stylesheet" href="css/style.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet" crossorigin="anonymous">
+    <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body>
     <button id="theme-toggle"></button>
+    <aside class="fixed right-0 top-0 h-full w-64 bg-black/60 text-white p-4">
+        <p>Faces detected: <span id="face-count">0</span></p>
+        <p>Confidence: <span id="face-confidence">0</span></p>
+        <p>Camera: <span id="camera-name"></span></p>
+        <p>Model status: <span id="model-status">loading...</span></p>
+    </aside>
     <header class="hero-section">
         <h1>Вашето Здраве в Огледалото</h1>
         <p>Получете персонален AI анализ на базата на снимка и начина Ви на живот.</p>
@@ -53,6 +60,7 @@
         </div>
     </div>
     <script src="js/main.js"></script>
+    <script src="js/face-info.js"></script>
     <script src="js/theme.js"></script>
 </body>
 </html>

--- a/js/face-info.js
+++ b/js/face-info.js
@@ -1,0 +1,37 @@
+// js/face-info.js
+// Обновява страничния панел със статус на разпознаването на лица
+
+document.addEventListener('DOMContentLoaded', () => {
+    const countEl = document.getElementById('face-count');
+    const confEl = document.getElementById('face-confidence');
+    const camEl = document.getElementById('camera-name');
+    const statusEl = document.getElementById('model-status');
+
+    let detector;
+
+    async function init() {
+        if (!('FaceDetector' in window)) {
+            statusEl.textContent = 'unsupported';
+            return;
+        }
+        detector = new FaceDetector();
+        statusEl.textContent = 'ready';
+    }
+
+    window.detectFaces = async function(img, sourceName = '') {
+        if (!detector) return;
+        try {
+            const faces = await detector.detect(img);
+            countEl.textContent = faces.length;
+            confEl.textContent = faces[0] && typeof faces[0].confidence !== 'undefined'
+                ? faces[0].confidence.toFixed(2)
+                : '0';
+            camEl.textContent = sourceName;
+        } catch (err) {
+            console.error('Face detection failed:', err);
+            statusEl.textContent = 'error';
+        }
+    };
+
+    init();
+});

--- a/js/main.js
+++ b/js/main.js
@@ -68,6 +68,11 @@ document.addEventListener('DOMContentLoaded', () => {
             
             base64Image = resizedImage;
             imagePreview.src = base64Image;
+            imagePreview.onload = () => {
+                if (window.detectFaces) {
+                    detectFaces(imagePreview, file.name);
+                }
+            };
 
             // Активираме бутона след успешна обработка
             analyzeBtn.disabled = false;

--- a/js/results.js
+++ b/js/results.js
@@ -22,13 +22,17 @@ document.addEventListener('DOMContentLoaded', () => {
         const container = document.getElementById('summary-card-container');
         container.innerHTML = `
             <div class="results-summary-card">
-                <img src="${userImage}" alt="User Photo">
+                <img id="result-photo" src="${userImage}" alt="User Photo">
                 <div>
                     <h2>Вашият доклад</h2>
                     <p>Възприемана възраст: <strong>${data.summary.perceived_age}</strong></p>
                 </div>
             </div>
         `;
+        const img = document.getElementById('result-photo');
+        if (window.detectFaces) {
+            img.onload = () => detectFaces(img, 'резултат');
+        }
     }
 
     function renderOverviewTab(data) {

--- a/results.html
+++ b/results.html
@@ -6,10 +6,17 @@
     <title>Вашият AI Лицев Анализ</title>
     <link rel="stylesheet" href="css/style.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
     <button id="theme-toggle"></button>
+    <aside class="fixed right-0 top-0 h-full w-64 bg-black/60 text-white p-4">
+        <p>Faces detected: <span id="face-count">0</span></p>
+        <p>Confidence: <span id="face-confidence">0</span></p>
+        <p>Camera: <span id="camera-name"></span></p>
+        <p>Model status: <span id="model-status">loading...</span></p>
+    </aside>
     <div class="container" id="results-page">
         <!-- Заглавна карта - винаги видима -->
         <div id="summary-card-container"></div>
@@ -27,6 +34,7 @@
         <div id="details" class="tab-content"></div>
     </div>
     <script src="js/results.js"></script>
+    <script src="js/face-info.js"></script>
     <script src="js/theme.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Tailwind CDN to `index.html` and `results.html`
- show real-time face detection info in a sidebar
- implement shared `face-info.js` for detection
- detect faces when image loads on both pages

## Testing
- `npm test` *(fails: package.json missing)*
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_686a8805336c8326b47ab538f45d480d