### PR TITLE
Add overlay canvas with animated grid

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -190,3 +190,24 @@ body {
 .progress-bar-container { margin-top: 0.5rem; }
 
 @keyframes fadeIn { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
+
+/* --- Utility classes similar to Tailwind --- */
+.relative { position: relative; }
+.absolute { position: absolute; }
+.inset-0 { top: 0; right: 0; bottom: 0; left: 0; }
+.opacity-50 { opacity: 0.5; }
+.bg-black\/30 { background-color: rgba(0, 0, 0, 0.3); }
+
+/* Neon glow for face frames */
+.neon-glow {
+    box-shadow: 0 0 8px rgba(0, 255, 255, 0.8), 0 0 16px rgba(0, 255, 255, 0.6);
+}
+
+.preview-container { position: relative; }
+
+.face-box {
+    position: absolute;
+    border: 2px solid cyan;
+    box-shadow: 0 0 6px rgba(0, 255, 255, 0.8), 0 0 12px rgba(0, 255, 255, 0.6);
+    pointer-events: none;
+}

--- a/index.html
+++ b/index.html
@@ -47,12 +47,16 @@
                 <p>Моля, използвайте снимка без грим, с неутрално изражение и добро осветление.</p>
                 <label for="file-upload" class="upload-btn">Изберете файл</label>
                 <input type="file" id="file-upload" accept="image/*" style="display:none;">
-                <img id="image-preview" src="" alt="Предварителен преглед">
+                <div class="preview-container relative">
+                    <canvas id="overlay" class="absolute inset-0 opacity-50 bg-black/30"></canvas>
+                    <img id="image-preview" src="" alt="Предварителен преглед" class="neon-glow">
+                </div>
                 <button id="analyze-btn" class="cta-button" disabled>АНАЛИЗИРАЙ СЕГА</button>
             </div>
         </div>
     </div>
     <script src="js/main.js"></script>
+    <script src="js/overlay.js"></script>
     <script src="js/theme.js"></script>
 </body>
 </html>

--- a/js/overlay.js
+++ b/js/overlay.js
@@ -1,0 +1,60 @@
+// js/overlay.js
+
+document.addEventListener('DOMContentLoaded', () => {
+    const canvas = document.getElementById('overlay');
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    const preview = document.getElementById('image-preview');
+
+    canvas.style.pointerEvents = 'none';
+
+    function resize() {
+        canvas.width = preview.clientWidth;
+        canvas.height = preview.clientHeight;
+    }
+
+    function drawGrid(step, offset) {
+        ctx.strokeStyle = 'cyan';
+        ctx.lineWidth = 1;
+        ctx.setLineDash([5, 5]);
+        for (let x = 0; x <= canvas.width; x += step) {
+            ctx.beginPath();
+            ctx.moveTo(x + offset, 0);
+            ctx.lineTo(x + offset, canvas.height);
+            ctx.stroke();
+        }
+        for (let y = 0; y <= canvas.height; y += step) {
+            ctx.beginPath();
+            ctx.moveTo(0, y + offset);
+            ctx.lineTo(canvas.width, y + offset);
+            ctx.stroke();
+        }
+        ctx.setLineDash([]);
+    }
+
+    let offset = 0;
+    let scanY = 0;
+
+    function animate() {
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        const step = canvas.width / 8;
+        drawGrid(step, offset);
+
+        ctx.strokeStyle = 'rgba(0,255,255,0.7)';
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.moveTo(0, scanY);
+        ctx.lineTo(canvas.width, scanY);
+        ctx.stroke();
+
+        offset = (offset + 0.5) % step;
+        scanY = (scanY + 2) % canvas.height;
+        requestAnimationFrame(animate);
+    }
+
+    window.addEventListener('resize', resize);
+    preview.addEventListener('load', resize);
+    resize();
+    animate();
+});
+


### PR DESCRIPTION
## Summary
- embed overlay canvas above uploaded image
- animate grid and scanning line on the canvas
- style overlay with utility classes and neon glow
- expose reusable face-box style for future use

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a8802e05c83269f3909bb2163383d