### PR TITLE
Fix Chart.js CDN link

### DIFF
--- a/results.html
+++ b/results.html
@@ -23,7 +23,7 @@
     </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Orbitron:wght@400;500;600&display=swap" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.js" integrity="sha384-FcQlsUOd0TJjROrBxhJdUhXTUgNJQxTMcxZe6nHbaEfFL1zjQ+bq/uRoBQxb0KMo" crossorigin="anonymous"></script>
 </head>
 <body class="font-poppins bg-gray-100 text-gray-900">
     <button id="theme-toggle"></button>


### PR DESCRIPTION
## Summary
- use fixed Chart.js version and integrity attribute

## Testing
- `npm install`
- `node scripts/seed_kv.js` *(fails: CF config missing)*

------
https://chatgpt.com/codex/tasks/task_e_686ac0f78fa483268d976eaadae20d30