### PR TITLE
Add products API with KV storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,12 @@ wrangler publish --name face-analysis-worker
    export KV_NAMESPACE_ID=YOUR_NAMESPACE_ID
    node scripts/seed_kv.js
    ```
-4. Publish the worker:
+4. Upload the initial products data:
+   ```bash
+   export KV_NAMESPACE_ID=YOUR_PRODUCTS_NAMESPACE_ID
+   node scripts/seed_products.js
+   ```
+5. Publish the worker:
    ```bash
    wrangler publish
    ```

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,6 +1,18 @@
 let productsData = { categories: [] };
 
 async function loadData() {
+    try {
+        const apiRes = await fetch('/products');
+        if (apiRes.ok) {
+            productsData = await apiRes.json();
+            localStorage.setItem('products', JSON.stringify(productsData));
+            fillGroupOptions();
+            return;
+        }
+    } catch (err) {
+        console.error('Неуспешно зареждане от /products', err);
+    }
+
     const stored = localStorage.getItem('products');
     if (stored) {
         productsData = JSON.parse(stored);
@@ -28,7 +40,19 @@ function fillGroupOptions() {
 
 function saveData() {
     localStorage.setItem('products', JSON.stringify(productsData));
-    alert('Данните са записани локално.');
+    fetch('/products', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(productsData)
+    })
+    .then(res => {
+        if (!res.ok) throw new Error('Server error');
+        alert('Данните са записани.');
+    })
+    .catch(err => {
+        console.error('Неуспешен запис към /products', err);
+        alert('Грешка при запис.');
+    });
 }
 
 document.getElementById('group-form').addEventListener('submit', e => {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "description": "Demo for analyzing selfies with OpenAI and Cloudflare Workers.",
   "scripts": {
-    "seed": "node scripts/seed_kv.js"
+    "seed": "node scripts/seed_kv.js",
+    "seed:products": "node scripts/seed_products.js"
   },
   "dependencies": {
     "node-fetch": "^3.3.2"

--- a/scripts/seed_products.js
+++ b/scripts/seed_products.js
@@ -1,0 +1,40 @@
+// Utility script to upload products.json into a KV namespace.
+// Requires CF_API_TOKEN, CF_ACCOUNT_ID and KV_NAMESPACE_ID env variables.
+
+if (typeof fetch !== 'function') {
+  try {
+    global.fetch = (...args) => import('node-fetch').then(({ default: fetch }) => fetch(...args));
+  } catch (err) {
+    console.error('Fetch API not available. Please use Node 18+ or install node-fetch.');
+    process.exit(1);
+  }
+}
+
+const fs = require('fs/promises');
+const { CF_API_TOKEN, CF_ACCOUNT_ID, KV_NAMESPACE_ID } = process.env;
+
+if (!CF_API_TOKEN || !CF_ACCOUNT_ID || !KV_NAMESPACE_ID) {
+  console.error('Missing CF_API_TOKEN, CF_ACCOUNT_ID or KV_NAMESPACE_ID');
+  process.exit(1);
+}
+
+async function put(key, value) {
+  const url = `https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/storage/kv/namespaces/${KV_NAMESPACE_ID}/values/${encodeURIComponent(key)}`;
+  const res = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      'Authorization': `Bearer ${CF_API_TOKEN}`
+    },
+    body: value
+  });
+  const data = await res.json();
+  if (!data.success) {
+    throw new Error(`Failed to set ${key}: ${JSON.stringify(data.errors)}`);
+  }
+  console.log(`Set ${key}`);
+}
+
+(async () => {
+  const data = await fs.readFile('data/products.json', 'utf8');
+  await put('products', data);
+})();

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,3 +7,9 @@ binding = "FACE_ADVICE_KV"
 # Replace with your actual IDs from the Cloudflare dashboard
 id = "ID_НА_ВАШИЯ_KV_NAMESPACE"
 preview_id = "PREVIEW_ID_НА_ВАШИЯ_KV_NAMESPACE"
+
+[[kv_namespaces]]
+binding = "PRODUCTS_KV"
+# Replace with your actual IDs for the products namespace
+id = "ID_НА_PRODUCTS_NAMESPACE"
+preview_id = "PREVIEW_ID_НА_PRODUCTS_NAMESPACE"


### PR DESCRIPTION
## Summary
- add `/products` routes in worker to read and store product data in KV
- expose PRODUCTS_KV namespace in `wrangler.toml`
- add script `seed_products.js` for uploading initial product data
- update admin panel to load and save products through the new API
- document new seeding step in README

## Testing
- `node -c src/worker.js`
- `node -c js/admin.js`
- `node -e "require('./scripts/seed_products.js');"` *(fails: Missing CF_API_TOKEN, CF_ACCOUNT_ID or KV_NAMESPACE_ID)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_686bc0a54e948326a7545ada14618d96