### PR TITLE
Add admin instructions and KV seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,39 @@ Small demo that analyzes a selfie with help from OpenAI and Cloudflare Workers.
 - `src/worker.js` – Cloudflare Worker
 - `assets/` – images and icons
 
+### Структура на `data/products.json`
+
+Файлът съдържа каталога с продукти и е организиран по категории:
+
+```json
+{
+  "categories": [
+    {
+      "id": "anti-aging",
+      "title": "Anti-Aging & Клетъчна Регенерация",
+      "image": "url",
+      "alt": "описание",
+      "products": [
+        {
+          "name": "Epitalon",
+          "tagline": "кратко резюме",
+          "effects": [
+            {"label": "Ефект", "score": "9", "width": "90%"}
+          ],
+          "description": "Пълен текст",
+          "research": {"source": "източник", "url": "линк"},
+          "variants": [
+            {"title": "Форма", "note": "бележка", "link": "линк"}
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+Всяка категория има `id`, видим `title`, изображение и масив от продукти. Продуктите описват ефекти, източник на изследване и различни налични форми.
+
 ## Конфигурация
 
 - **OPENAI_API_KEY** – приватен ключ за достъп до OpenAI. Подавайте го като секрет чрез:
@@ -48,7 +81,11 @@ wrangler publish --name face-analysis-worker
    export KV_NAMESPACE_ID=YOUR_NAMESPACE_ID
    node scripts/seed_kv.js
    ```
-4. Publish the worker:
+4. Optionally seed the KV with the product catalog:
+   ```bash
+   npm run seed:products
+   ```
+5. Publish the worker:
    ```bash
    wrangler publish
    ```
@@ -57,3 +94,35 @@ wrangler publish --name face-analysis-worker
 ## Privacy
 
 Uploaded images are sent to your Cloudflare Worker and forwarded to OpenAI for analysis. The demo does not store the images after the request completes, but keep in mind they transit through these services.
+
+## Административен панел
+
+Файлът `admin.html` позволява локално редактиране на каталога с продукти.
+
+1. Отворете `admin.html` в браузър.
+2. Добавете категории и продукти чрез формите.
+3. Натиснете **Запази**, за да съхраните промените в `localStorage`.
+4. За да ги запишете във файла, копирайте съдържанието на `localStorage` ключа `products` обратно в `data/products.json`.
+
+Панелът е предназначен само за локална подготовка на данните и не комуникира с Worker-а.
+
+## Cloudflare Worker API
+
+Публикуваният Worker приема POST заявка с изображение и отговори от формата:
+
+```json
+{
+  "image": "data:image/png;base64,....",
+  "answers": { "sleep": "good", ... }
+}
+```
+
+Отговорът е JSON с анализ и препоръки. Примерно извикване с `curl`:
+
+```bash
+curl -X POST $WORKER_URL \
+     -H 'Content-Type: application/json' \
+     -d @payload.json
+```
+
+Адресът на Worker-а се задава в `loading.html` чрез константата `workerUrl`.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "description": "Demo for analyzing selfies with OpenAI and Cloudflare Workers.",
   "scripts": {
-    "seed": "node scripts/seed_kv.js"
+    "seed:advice": "node scripts/seed_kv.js",
+    "seed:products": "node scripts/seed_products_kv.js"
   },
   "dependencies": {
     "node-fetch": "^3.3.2"

--- a/scripts/seed_products_kv.js
+++ b/scripts/seed_products_kv.js
@@ -1,0 +1,48 @@
+// Utility script to upload products JSON into a Cloudflare KV namespace.
+// Reads data/products.json and stores it under the PRODUCTS key.
+// Requires CF_API_TOKEN, CF_ACCOUNT_ID and KV_NAMESPACE_ID env vars.
+
+if (typeof fetch !== 'function') {
+  try {
+    global.fetch = (...args) =>
+      import('node-fetch').then(({ default: fetch }) => fetch(...args));
+  } catch (err) {
+    console.error('Fetch API not available. Use Node 18+ or install node-fetch.');
+    process.exit(1);
+  }
+}
+
+const { CF_API_TOKEN, CF_ACCOUNT_ID, KV_NAMESPACE_ID } = process.env;
+
+if (!CF_API_TOKEN || !CF_ACCOUNT_ID || !KV_NAMESPACE_ID) {
+  console.error('Missing CF_API_TOKEN, CF_ACCOUNT_ID or KV_NAMESPACE_ID');
+  process.exit(1);
+}
+
+import { readFileSync } from 'fs';
+
+const productsPath = new URL('../data/products.json', import.meta.url);
+let products;
+try {
+  products = readFileSync(productsPath, 'utf8');
+} catch (err) {
+  console.error('Unable to read products.json:', err);
+  process.exit(1);
+}
+
+async function put(key, value) {
+  const url = `https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/storage/kv/namespaces/${KV_NAMESPACE_ID}/values/${encodeURIComponent(key)}`;
+  const res = await fetch(url, {
+    method: 'PUT',
+    headers: { 'Authorization': `Bearer ${CF_API_TOKEN}` },
+    body: value,
+  });
+  const data = await res.json();
+  if (!data.success) throw new Error(`Failed to set ${key}: ${JSON.stringify(data.errors)}`);
+  console.log(`Set ${key}`);
+}
+
+put('PRODUCTS', products).catch(err => {
+  console.error('Seeding failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- document the product catalog JSON format
- explain how to publish and call the Cloudflare Worker API
- add admin page usage notes and example curl
- describe seeding the product catalog into KV
- add `seed_products_kv.js` and expose npm script

## Testing
- `node -e "console.log('Node version:', process.version)"`


------
https://chatgpt.com/codex/tasks/task_e_686bc0b1faf483269744a3ba71b80d91