### PR TITLE
Reverse score scale and add backend example

### DIFF
--- a/js/results.js
+++ b/js/results.js
@@ -30,7 +30,8 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- RENDER HELPER FUNCTIONS ---
 
     function renderSummaryAndGauge(summary) {
-        const score = summary?.overall_skin_health_score ?? 0;
+        const rawScore = summary?.overall_skin_health_score ?? 0;
+        const score = 11 - rawScore;
         const scorePercentage = score * 10;
         
         document.getElementById('overall-score-value').textContent = score;
@@ -62,14 +63,14 @@ document.addEventListener('DOMContentLoaded', () => {
         
         const allMetrics = {...antiAging, ...health};
         const labels = Object.keys(metricLabels);
-        const data = labels.map(labelKey => allMetrics[labelKey] ?? 0);
+        const data = labels.map(labelKey => 11 - (allMetrics[labelKey] ?? 0));
 
         new Chart(ctx, {
             type: 'radar',
             data: {
                 labels: labels.map(key => metricLabels[key]),
                 datasets: [{
-                    label: 'Оценка на Показателите (по-малко е по-добре)',
+                    label: 'Оценка на Показателите (по-голяма стойност е по-добре)',
                     data: data,
                     backgroundColor: 'rgba(255, 0, 255, 0.2)',
                     borderColor: 'rgba(255, 0, 255, 1)',
@@ -123,6 +124,20 @@ document.addEventListener('DOMContentLoaded', () => {
                     }
                 }
             }
+        });
+
+        updateMetricCards(allMetrics, metricLabels);
+    }
+
+    function updateMetricCards(metrics, labelMap) {
+        Object.keys(labelMap).forEach(key => {
+            const card = document.getElementById(`metric-${key}`);
+            if (!card) return;
+            const raw = metrics[key] ?? 0;
+            const score = 11 - raw;
+            card.querySelector('.metric-score').textContent = `${score}/10`;
+            const bar = card.querySelector('.progress-bar');
+            if (bar) bar.style.width = `${score * 10}%`;
         });
     }
 

--- a/results.html
+++ b/results.html
@@ -43,7 +43,7 @@
                     <div class="score-gauge" id="score-gauge">
                         <div class="score-value" id="overall-score-value">--</div>
                     </div>
-                    <div class="score-label">Общ Здравен Индекс</div>
+                    <div class="score-label">Общ Здравен Индекс (10 е най-добър)</div>
                 </div>
                 <div class="summary-details">
                     <p><strong>Предполагаема възраст:</strong> <span id="perceived-age">--</span></p>

--- a/worker.js
+++ b/worker.js
@@ -1,0 +1,39 @@
+export default {
+  async fetch(request, env) {
+    if (request.method !== 'POST') {
+      return new Response('Method Not Allowed', { status: 405 });
+    }
+
+    const { image, answers } = await request.json();
+
+    const prompt = `Анализирай изображението и отговорите. За всеки показател дай оценка от 1 до 10, като 10 е най-добър резултат. Върни JSON със структурата:\n{
+      "summary": {"overall_skin_health_score": <number>, "perceived_age": <number>, "key_findings": ["..."]},
+      "anti_aging": {"wrinkle_score": <number>, "volume_loss_score": <number>, "pigmentation_score": <number>},
+      "health_indicators": {"hydration_level_score": <number>, "inflammation_score": <number>, "stress_impact_score": <number>},
+      "findings_map": {"HIGH_WRINKLE_SCORE": <boolean>, "HIGH_PIGMENTATION_SCORE": <boolean>, "POOR_HYDRATION": <boolean>, "HIGH_INFLAMMATION": <boolean>, "HIGH_STRESS_IMPACT": <boolean>}
+    }`;
+
+    const aiPayload = {
+      model: 'gpt-4o',
+      messages: [
+        { role: 'system', content: 'Кожен специалист AI' },
+        { role: 'user', content: prompt }
+      ],
+      max_tokens: 800
+    };
+
+    const resp = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${env.OPENAI_API_KEY}`
+      },
+      body: JSON.stringify(aiPayload)
+    });
+
+    const { choices } = await resp.json();
+    const analysis = JSON.parse(choices[0].message.content);
+
+    return Response.json(analysis);
+  }
+};


### PR DESCRIPTION
## Summary
- switch front-end scoring logic so 10 is best
- update radar label and gauge text in results page
- show metric values via progress bars with the new orientation
- add example Cloudflare worker with prompt describing the new 1-10 scale

## Testing
- `node --check js/results.js`
- `node --check worker.js`


------
https://chatgpt.com/codex/tasks/task_e_686c7dd0950c83268dbc93d8f54f8482