### PR TITLE
Добавен клас за грешка в полетата и нова валидация

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -195,6 +195,11 @@ body {
     transition: border-color 0.2s, box-shadow 0.2s;
 }
 
+/* Highlight invalid inputs */
+.input-error {
+    border-color: var(--danger-color);
+}
+
 /* Custom Radio Buttons */
 .radio-group { display: flex; gap: 1rem; }
 .radio-group label { display: flex; align-items: center; cursor: pointer; }

--- a/js/main.js
+++ b/js/main.js
@@ -190,16 +190,23 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     
     function validateForm() {
-        const data = JSON.parse(localStorage.getItem('savedFormData') || '{}');
-        if (!data.birthdate) {
+        const birthdateInput = document.getElementById('birthdate');
+        let isValid = true;
+
+        if (!birthdateInput.value) {
+            birthdateInput.classList.add('input-error');
             showError("Моля, въведете дата на раждане.");
-            return false;
+            isValid = false;
+        } else {
+            birthdateInput.classList.remove('input-error');
         }
+
         if (!analysisData.image) {
             showError("Моля, качете изображение.");
-            return false;
+            isValid = false;
         }
-        return true;
+
+        return isValid;
     }
 
     // --- UI UTILITY FUNCTIONS ---


### PR DESCRIPTION
## Обобщение
- добавен `.input-error` в `style.css` за подчертаване на невалидни полета
- актуализирана функция `validateForm()` в `main.js` – при липса на дата на раждане полето се отбелязва с червена рамка и съобщението остава през `showError()`
- след въвеждане на валидна дата рамката се премахва

## Тестове
- `npm test` *(очаквано неуспех – липсва `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_686c7efeb9b483269d7477ce1629c97f