### PR TITLE
Fix missing libraries and send image data to OpenAI

### DIFF
--- a/results.html
+++ b/results.html
@@ -166,9 +166,11 @@
     
     <!-- External library for creating image from HTML -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
-    
+
+    <!-- Library for radar chart visualisation -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+
     <!-- Main JS file for this page -->
     <script src="js/results.js"></script>
 
-</body>
-</html>
+</body></html>

--- a/worker.js
+++ b/worker.js
@@ -17,7 +17,13 @@ export default {
       model: 'gpt-4o',
       messages: [
         { role: 'system', content: 'Кожен специалист AI' },
-        { role: 'user', content: prompt }
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: `${prompt}\n${JSON.stringify(answers)}` },
+            { type: 'image_url', image_url: { url: image, detail: 'auto' } }
+          ]
+        }
       ],
       max_tokens: 800
     };


### PR DESCRIPTION
## Summary
- load Chart.js on the results page
- include questionnaire answers and uploaded image when calling OpenAI

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686da158595083269258581b13771b08