### PR TITLE
Add advice retrieval from KV

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,3 +61,12 @@ OpenAI API (GPT-4o)
 
 ## Конфигуриране на worker.js
 За инструкции как да разположите бекенд частта вижте [docs/worker_setup.md](docs/worker_setup.md).
+
+### Променлива ADVICE_KV
+Worker-ът използва Cloudflare KV за съхранение на съветите. В `wrangler.toml` добавете KV namespace, вързан като `ADVICE_KV`, например:
+
+```toml
+kv_namespaces = [
+  { binding = "ADVICE_KV", id = "<YOUR_KV_ID>" }
+]
+```


### PR DESCRIPTION
## Summary
- use `env.ADVICE_KV` to load predefined advice
- document the new environment variable in the README

## Testing
- `npm test` *(fails: no package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686da99afb248326882e5870255eefc1