### PR TITLE
Fix score calculations

### DIFF
--- a/js/results.js
+++ b/js/results.js
@@ -30,8 +30,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- RENDER HELPER FUNCTIONS ---
 
     function renderSummaryAndGauge(summary) {
-        const rawScore = summary?.overall_skin_health_score ?? 0;
-        const score = 11 - rawScore;
+        const score = summary?.overall_skin_health_score ?? 0;
         const scorePercentage = score * 10;
         
         document.getElementById('overall-score-value').textContent = score;
@@ -63,7 +62,7 @@ document.addEventListener('DOMContentLoaded', () => {
         
         const allMetrics = {...antiAging, ...health};
         const labels = Object.keys(metricLabels);
-        const data = labels.map(labelKey => 11 - (allMetrics[labelKey] ?? 0));
+        const data = labels.map(labelKey => allMetrics[labelKey] ?? 0);
 
         new Chart(ctx, {
             type: 'radar',
@@ -133,8 +132,7 @@ document.addEventListener('DOMContentLoaded', () => {
         Object.keys(labelMap).forEach(key => {
             const card = document.getElementById(`metric-${key}`);
             if (!card) return;
-            const raw = metrics[key] ?? 0;
-            const score = 11 - raw;
+            const score = metrics[key] ?? 0;
             card.querySelector('.metric-score').textContent = `${score}/10`;
             const bar = card.querySelector('.progress-bar');
             if (bar) bar.style.width = `${score * 10}%`;

--- a/tests/test_results.js
+++ b/tests/test_results.js
@@ -1,0 +1,47 @@
+const { JSDOM, VirtualConsole } = require('jsdom');
+const path = require('path');
+
+const virtualConsole = new VirtualConsole();
+virtualConsole.sendTo(console);
+
+const example = {
+  summary: { overall_skin_health_score: 8, perceived_age: '25', key_findings: ['Пример'] },
+  anti_aging: { wrinkle_score: 7, volume_loss_score: 5 },
+  health_indicators: { hydration_level_score: 6 },
+  advice: { HIGH_INFLAMMATION: 'Възпаление: Намалете стреса' }
+};
+
+const html = `<!DOCTYPE html><html><body>
+<div id="overall-score-value"></div>
+<span id="perceived-age"></span>
+<span id="key-findings"></span>
+<canvas id="metricsRadarChart"></canvas>
+<div id="advice-container"></div>
+<script src="js/results.js"></script>
+</body></html>`;
+
+(async () => {
+  const base = path.resolve(__dirname, '..');
+  const dom = new JSDOM(html, {
+    runScripts: 'dangerously',
+    resources: 'usable',
+    pretendToBeVisual: true,
+    url: 'file://' + base + '/test.html',
+    virtualConsole,
+    beforeParse(window) {
+      window.sessionStorage.setItem('analysisResult', JSON.stringify(example));
+      window.Chart = function() { return { destroy() {} }; };
+      window.HTMLCanvasElement.prototype.getContext = () => ({})
+    }
+  });
+
+  await new Promise(resolve => {
+    if (dom.window.document.readyState === 'complete') return resolve();
+    dom.window.addEventListener('DOMContentLoaded', () => setTimeout(resolve, 100));
+  });
+
+  const score = dom.window.document.getElementById('overall-score-value').textContent;
+  const age = dom.window.document.getElementById('perceived-age').textContent;
+  console.log('Score:', score);
+  console.log('Age:', age);
+})();


### PR DESCRIPTION
## Summary
- remove 11-score inversions in results.js
- interpret raw metric values directly
- add simple jsdom test script for result page

## Testing
- `node --check js/results.js`
- `node tests/test_results.js` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_686db42187b88326964fa04297360154